### PR TITLE
actions: use github-actions[bot] for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple


### PR DESCRIPTION
## Description of Issue

It's now using my account to make release PRs because I'm letting it use my own token. Not good.

## Review
- [x] Commits are atomic
- [x] Checks are passing
- [x] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
