### PR TITLE
feat(service): add crash recovery

### DIFF
--- a/src/service_layer/service.py
+++ b/src/service_layer/service.py
@@ -7,7 +7,7 @@ from src.config.config import ConfigModel, ScriptConfig
 from src.core.decorators import catch_and_log_exception
 from src.core.exceptions import NoScriptWithModel
 from src.core.types import TaskStatus
-from src.domain.commands import CreateTask
+from src.domain.commands import CreateTask, RunTask
 from src.domain.model import Task
 from src.service_layer.default_handlers import (
     COMMAND_HANDLERS,
@@ -70,8 +70,17 @@ class Service:
 
         self._shutdown = False
 
+        self._resume_on_startup()
+
     def shutdown(self) -> None:
         self._shutdown = True
+
+    def _resume_on_startup(self) -> None:
+        with self._uow:
+            running_tasks = self._uow.tasks.get_by_status(TaskStatus.RUNNING)
+
+            for task in running_tasks:
+                self._broker.put(self._get_run_task_command(task))
 
     async def main_loop(self) -> None:
         await asyncio.gather(
@@ -152,4 +161,23 @@ class Service:
             filesystem=task.filesystem,
             script_path=script.path,
             model=task.model,
+        )
+
+    def _get_run_task_command(self, task: Task) -> RunTask:
+        script: ScriptConfig | None = next(
+            (
+                script
+                for script in self._config.scripts
+                if script.model_name == task.model
+            ),
+            None,
+        )
+
+        if script is None:
+            raise NoScriptWithModel(task.model)
+
+        return RunTask(
+            task_id=task._id,
+            filesystem_path=task.filesystem,
+            script_path=task.script_path,
         )

--- a/tests/unit/service_layer/test_service.py
+++ b/tests/unit/service_layer/test_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -6,11 +7,48 @@ from src.config.config import ConfigModel
 from src.core.response_types import Task
 from src.core.types import UUID, Model, TaskStatus
 from src.domain import commands, events
+from src.domain.model import Task as ModelTask
 from src.service_layer.service import Service
 from src.service_layer.unit_of_work.publishing_uow import PublishingUoW
 from tests.integration.service_layer.fakes import FakeUoW
 from tests.unit.service_layer.fake_handlers import ExceptionResults, FakeHandlers
 from tests.unit.service_layer.fake_http_client import FakeHTTPClient
+
+
+def test_service_resumes_running_tasks(config_model: ConfigModel):
+    dt = datetime.now()
+    task = ModelTask(
+        owner_id=UUID("123"),
+        filesystem=Path("dataset"),
+        script_path=Path("script"),
+        created_at=dt,
+        status=TaskStatus.RUNNING,
+        model=Model.VTC,
+        _id=UUID("1"),
+    )
+
+    uow = PublishingUoW(FakeUoW())
+    handlers = FakeHandlers(uow, {})
+    http_client = FakeHTTPClient(results=[])
+
+    with uow:
+        uow.tasks.save(task)
+
+        uow.commit()
+
+    service = Service(
+        uow=uow,
+        http_client=http_client,
+        config=config_model,
+        event_handlers=handlers.event_handlers,
+        command_handlers=handlers.command_handlers,
+    )
+
+    queue = service._broker.command_queue._queue
+    assert queue.qsize() == 1
+    assert queue.get().item == commands.RunTask(
+        task_id=UUID("1"), filesystem_path=Path("dataset"), script_path=Path("script")
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description of Issue

Crash recovery in this sense means adding tasks back that were flagged as running
Tasks are flagged as running from the moment they are run, so this should be quite robust.

## Description of Solution

Simply add tasks to the broker during service object initialization

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
